### PR TITLE
Update allC1Users to filter by package instead of course

### DIFF
--- a/services/usersServices.js
+++ b/services/usersServices.js
@@ -9,10 +9,7 @@ const allUsers = async () =>
 
 const allC1Users = async () =>
   await Users.find({
-    $or: [
-      { course: { $regex: "10", $options: "i" } },
-      { course: { $regex: "11", $options: "i" } },
-    ],
+    package: { $regex: "sc", $options: "i" },
   }).select(
     "-visitedTime -adult -zoomMail -token -createdAt -updatedAt -feedback -__v"
   );


### PR DESCRIPTION
Changed the allC1Users query to filter users by the 'package' field matching 'sc' (case-insensitive) instead of filtering by 'course' values containing '10' or '11'