### PR TITLE
Fix HTTP status codes in lesson results controllers

### DIFF
--- a/controllers/uniLessonResults/addQuestion.js
+++ b/controllers/uniLessonResults/addQuestion.js
@@ -3,7 +3,7 @@ const { newQuestion } = require("../../services/uniLessonResultsServices");
 const addQuestion = async (req, res) => {
   try {
     const updatedLesson = await newQuestion(req.params.lessonId, req.body);
-    res.status(200).json(updatedLesson);
+    res.status(201).json(updatedLesson);
   } catch (error) {
     if (error.message === "Lesson not found") {
       return res.status(404).json({ error: error.message });

--- a/controllers/uniLessonResults/getLessonsByGroup.js
+++ b/controllers/uniLessonResults/getLessonsByGroup.js
@@ -1,8 +1,10 @@
-const { findLessonsByGroup } = require("../../services/uniLessonResultsServices");
+const {
+  findLessonsByGroup,
+} = require("../../services/uniLessonResultsServices");
 
 const getLessonsByGroup = async (req, res) => {
   try {
-    res.status(201).json(await findLessonsByGroup(req.params.group));
+    res.status(200).json(await findLessonsByGroup(req.params.group));
   } catch (e) {
     res.status(500).json({ error: "Internal Server Error" });
   }

--- a/controllers/uniLessonResults/getLessonsByGroupAndDate.js
+++ b/controllers/uniLessonResults/getLessonsByGroupAndDate.js
@@ -1,9 +1,11 @@
-const { findLessonsByGroupAndDate } = require("../../services/uniLessonResultsServices");
+const {
+  findLessonsByGroupAndDate,
+} = require("../../services/uniLessonResultsServices");
 
 const getLessonsByGroupAndDate = async (req, res) => {
   try {
     res
-      .status(201)
+      .status(200)
       .json(await findLessonsByGroupAndDate(req.params.group, req.params.date));
   } catch (e) {
     res.status(500).json({ error: "Internal Server Error" });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-server",
-  "version": "1.1.20.46",
+  "version": "1.1.20.47",
   "private": true,
   "scripts": {
     "start": "cross-env NODE_ENV=production node ./server.js",


### PR DESCRIPTION
Updated addQuestion to return 201 on successful creation and changed getLessonsByGroup and getLessonsByGroupAndDate to return 200 for successful fetches. This ensures correct and consistent use of HTTP status codes in the API responses.