### PR TITLE
Add holiday status support to timetable courses

### DIFF
--- a/controllers/timetable/editTimetableHolidayStatus.js
+++ b/controllers/timetable/editTimetableHolidayStatus.js
@@ -1,0 +1,9 @@
+const { updateCourseHolidayStatus } = require("../../services/timetableServices");
+
+const editTimetableHolidayStatus = async (req, res) => {
+  console.log(req.body);
+  
+  res.status(200).json(await updateCourseHolidayStatus(req.params.id, req.body));
+};
+
+module.exports = editTimetableHolidayStatus;

--- a/db/models/timetableModel.js
+++ b/db/models/timetableModel.js
@@ -24,6 +24,10 @@ const timetable = new Schema(
         teacher: { type: String },
       },
     ],
+    isHoliday: {
+      type: Boolean,
+      required: [true, "No holiday status"],
+    },
   },
   {
     versionKey: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ap-server",
-  "version": "1.1.20.48",
+  "version": "1.1.20.49",
   "private": true,
   "scripts": {
     "start": "cross-env NODE_ENV=production node ./server.js",

--- a/routes/timetable.js
+++ b/routes/timetable.js
@@ -12,6 +12,7 @@ const removeTimetable = require("../controllers/timetable/removeTimetable");
 const removeScheduleFromTimetable = require("../controllers/timetable/removeScheduleFromTimetable");
 const updateScheduleInTimetable = require("../controllers/timetable/updateScheduleInTimetable");
 const editTimetableLevelCourse = require("../controllers/timetable/editTimetableLevelCourse");
+const editTimetableHolidayStatus = require("../controllers/timetable/editTimetableHolidayStatus");
 
 const router = express.Router();
 
@@ -28,5 +29,7 @@ router.delete("/:id", removeTimetable);
 router.patch("/course/:id", editTimetableLevelCourse);
 
 router.patch("/schedule/:id", removeScheduleFromTimetable);
+
+router.patch("/course/holiday/:id", editTimetableHolidayStatus);
 
 module.exports = router;

--- a/schema/timetableSchema.js
+++ b/schema/timetableSchema.js
@@ -14,6 +14,7 @@ const timetableSchema = Joi.object({
       teacher: Joi.string().empty(""),
     })
   ),
+  isHoliday: Joi.boolean().required(),
 });
 
 const validateTimetable = ({ body }, res, next) => {

--- a/services/timetableServices.js
+++ b/services/timetableServices.js
@@ -17,6 +17,9 @@ const updateTimetable = async (id, body) =>
     { upsert: true, new: true }
   );
 
+const updateCourseHolidayStatus = async (id, body) =>
+  await Timetable.findByIdAndUpdate(id, body, { new: true });
+
 const updateOnlyTimetableInfo = async (id, body) =>
   await Timetable.findByIdAndUpdate(id, body, { new: true });
 
@@ -33,6 +36,7 @@ module.exports = {
   findTimetable,
   newTimetable,
   updateTimetable,
+  updateCourseHolidayStatus,
   updateOnlyTimetableInfo,
   updateTimetableWithoutCourse,
   deleteTimetable,


### PR DESCRIPTION
Introduces an 'isHoliday' boolean field to the timetable model and schema, adds API endpoint and service for updating a course's holiday status, and wires up the new controller in the routes. This enables marking timetable courses as holidays and updating their status via PATCH requests.